### PR TITLE
Refactoring to implement plugin output system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 LABEL   Name="Redismoke"
-ENTRYPOINT [ "/usr/bin/python3", "/opt/redismoke/redismoke.py" ]
+ENTRYPOINT [ "/bin/sh", "/opt/redismoke/docker-entrypoint.sh" ]
 CMD [ "/etc/redismoke.yml" ]
 
 RUN apk add --update python3 py-pip
@@ -10,6 +10,7 @@ WORKDIR /opt/redismoke
 COPY requirements.txt /opt/redismoke/
 RUN pip3 install -r requirements.txt
 
+COPY docker-entrypoint.sh /opt/redismoke/docker-entrypoint.sh
 COPY src /opt/redismoke
 
 LABEL   Version=v2.0.0

--- a/confs/master1.conf
+++ b/confs/master1.conf
@@ -1,2 +1,3 @@
+save ""
 requirepass 123456
 #slaveof NO ONE

--- a/confs/master2.conf
+++ b/confs/master2.conf
@@ -1,1 +1,2 @@
+save ""
 #slaveof NO ONE

--- a/confs/slave1.conf
+++ b/confs/slave1.conf
@@ -1,3 +1,4 @@
+save ""
 masterauth 123456
 requirepass 123456
 slaveof master1 6379

--- a/confs/slave2.conf
+++ b/confs/slave2.conf
@@ -1,3 +1,4 @@
+save ""
 masterauth 123456
 requirepass 123456
 #slaveof NO ONE #intentionally wrong

--- a/confs/slave3.conf
+++ b/confs/slave3.conf
@@ -1,1 +1,2 @@
+save ""
 slaveof master2 6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   master1:
     container_name: redismoke_master1
     image: redis:alpine
-    command: redis-server /confs/master1.conf
+    command: /confs/master1.conf
     ports:
       - 6379
     volumes:
@@ -11,7 +11,7 @@ services:
   master2:
     container_name: redismoke_master2
     image: redis:alpine
-    command: redis-server /confs/master2.conf
+    command: /confs/master2.conf
     ports:
       - 6379
     volumes:
@@ -19,7 +19,7 @@ services:
   slave1:
     container_name: redismoke_slave1
     image: redis:alpine
-    command: redis-server /confs/slave1.conf
+    command: /confs/slave1.conf
     ports:
       - 6379
     volumes:
@@ -29,7 +29,7 @@ services:
   slave2:
     container_name: redismoke_slave2
     image: redis:alpine
-    command: redis-server /confs/slave2.conf
+    command: /confs/slave2.conf
     ports:
       - 6379
     volumes:
@@ -39,7 +39,7 @@ services:
   slave3:
     container_name: redismoke_slave3
     image: redis:alpine
-    command: redis-server /confs/slave3.conf
+    command: /confs/slave3.conf
     ports:
       - 6379
     volumes:

--- a/docker-compose_solarwinds.yml
+++ b/docker-compose_solarwinds.yml
@@ -48,7 +48,7 @@ services:
       - master2
   redismoke:
     build: .
-    command: --config /confs/config.yml
+    command: "--config /confs/config.yml --solarwinds"
     volumes:
       - ./confs:/confs
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+set -- python3 /opt/redismoke/redismoke.py $@
+
+exec "$@"

--- a/src/RedisServer.py
+++ b/src/RedisServer.py
@@ -12,6 +12,7 @@ class NoKeyException(Exception):
 
 class RedisServer(object):
     """ Generic Redis Server object """
+    # pylint: disable=R0902
     def __init__(self, conf, master=None):
         self.name = conf['name'] if 'name' in conf and conf['name'] != "" else "Unammed"
         self.address = conf['address']

--- a/src/RedisServer.py
+++ b/src/RedisServer.py
@@ -12,12 +12,24 @@ class NoKeyException(Exception):
 
 class RedisServer(object):
     """ Generic Redis Server object """
-    def __init__(self, conf):
+    def __init__(self, conf, master=None):
         self.name = conf['name'] if 'name' in conf and conf['name'] != "" else "Unammed"
         self.address = conf['address']
         self.port = conf['port'] if 'port' in conf and conf['port'] != "" else 6379
         self.password = conf['pass'] if 'pass' in conf else ""
         self.conn = None
+        self.ok = None
+        self.reason = None
+        self.master = master
+
+    def setStatus(self, ok, reason=None):
+        """ Set a server test outcome and reason """
+        self.ok = ok
+        self.reason = reason
+
+    def getStatus(self):
+        """ Return a boolean with the test outcome and the reason """
+        return self.ok, self.reason
 
     def disconnect(self):
         """ Close the connection to the RedisServer """

--- a/src/RedisTest.py
+++ b/src/RedisTest.py
@@ -60,45 +60,45 @@ class RedisTest(object):
             ok = self._groupOk(master) and ok
         return ok
 
-    class RedisTestMsg(object):
-        def __init__(self, testId, success, action, master, slave=None, reason=None):
-            self.testId = testId
-            self.success = success
-            self.action = action
-            self.master = master
-            self.slave = slave
-            self.reason = reason
+class RedisTestMsg(object):
+    def __init__(self, testId, success, action, master, slave=None, reason=None):
+        self.testId = testId
+        self.success = success
+        self.action = action
+        self.master = master
+        self.slave = slave
+        self.reason = reason
 
-        def _action(self):
-            if self.slave is None:
-                subject = "master \"{}\"".format(self.master.name)
-            else:
-                subject = "slave \"{}\" of master \"{}\"".format(self.slave.name, self.master.name)
+    def _action(self):
+        if self.slave is None:
+            subject = "master \"{}\"".format(self.master.name)
+        else:
+            subject = "slave \"{}\" of master \"{}\"".format(self.slave.name, self.master.name)
 
-            if self.action == 'w':
-                return "writing to {}".format(subject)
-            elif self.action == 'r':
-                return "reading from {}".format(subject)
-            else:
-                return "Unknown"
+        if self.action == 'w':
+            return "writing to {}".format(subject)
+        elif self.action == 'r':
+            return "reading from {}".format(subject)
+        else:
+            return "Unknown"
 
-        def _failure(self):
-            """ Print a standardized test failure message """
-            if self.reason is not None:
-                return "FAILURE[{}]: {}. Reason: {}.".format(self.testId, self._action(), self.reason)
-            else:
-                return "FAILURE[{}]: {}. Stack trace: ".format(self.testId, self._action())
-                ## TODO: Fix this
-                print_exc()
-            sys.stdout.flush()
+    def _failure(self):
+        """ Print a standardized test failure message """
+        if self.reason is not None:
+            return "FAILURE[{}]: {}. Reason: {}.".format(self.testId, self._action(), self.reason)
+        else:
+            return "FAILURE[{}]: {}. Stack trace: ".format(self.testId, self._action())
+            ## TODO: Fix this
+            print_exc()
+        sys.stdout.flush()
 
-        def _success(self, master, slave=None):
-            """ Print a standardized test success message """
-            return "SUCCESS[{}]: {}.".format(self.testId, self._action())
-            sys.stdout.flush()
+    def _success(self, master, slave=None):
+        """ Print a standardized test success message """
+        return "SUCCESS[{}]: {}.".format(self.testId, self._action())
+        sys.stdout.flush()
 
-        def __str__(self):
-            if self.success:
-                return self._success()
-            else:
-                return self._failure()
+    def __str__(self):
+        if self.success:
+            return self._success()
+        else:
+            return self._failure()

--- a/src/RedisTest.py
+++ b/src/RedisTest.py
@@ -83,6 +83,7 @@ class RedisTestMsg(object):
         self.success = server.getStatus()[0]
         self.reason = server.getStatus()[1]
         self.action = action
+        self.server = server
         self.master = server.master if server.master != None else server
         self.slave = server if server.master != None else None
 
@@ -93,11 +94,12 @@ class RedisTestMsg(object):
             subject = "slave \"{}\" of master \"{}\"".format(self.slave.name, self.master.name)
 
         if self.action == 'w':
-            return "writing to {}".format(subject)
+            action = "writing to {}".format(subject)
         elif self.action == 'r':
-            return "reading from {}".format(subject)
+            action = "reading from {}".format(subject)
         else:
-            return "Unknown"
+            action = "Unknown"
+        return action
 
     def __str__(self):
         raise NotImplementedError
@@ -106,17 +108,15 @@ class RedisTestMsgOneline(RedisTestMsg):
     """ Informative message of the test result """
     def _failure(self):
         """ Print a standardized test failure message """
-        if self.reason is not None:
-            return "FAILURE[{}]: {}. Reason: {}.".format(self.testId, self._action(), self.reason)
+        if self.reason:
+            msg = "FAILURE[{}]: {}. Reason: {}.".format(self.testId, self._action(), self.reason)
         else:
-            return "FAILURE[{}]: {}. See stack trace.".format(self.testId, self._action())
+            msg = "FAILURE[{}]: {}. See stack trace.".format(self.testId, self._action())
+        return msg
 
     def _success(self):
         """ Print a standardized test success message """
         return "SUCCESS[{}]: {}.".format(self.testId, self._action())
 
     def __str__(self):
-        if self.success:
-            return self._success()
-        else:
-            return self._failure()
+        return self._success() if self.success else self._failure()

--- a/src/RedisTestSolarwinds.py
+++ b/src/RedisTestSolarwinds.py
@@ -1,0 +1,21 @@
+import sys
+from RedisTest import RedisTestMsg
+
+class RedisTestMsgSolarwinds(RedisTestMsg):
+    def _failure(self):
+        """ Print a standardized test failure message """
+        if self.reason is not None:
+            return "FAILURE[{}]: {}. Reason: {}.".format(self.testId, self._action(), self.reason)
+        else:
+            return "FAILURE[{}]: {}. See stack trace.".format(self.testId, self._action())
+        sys.stdout.flush()
+
+    def _success(self):
+        """ Print a standardized test success message """
+        return "SUCCESS[{}]: {}.".format(self.testId, self._action())
+
+    def __str__(self):
+        if self.success:
+            return self._success()
+        else:
+            return self._failure()

--- a/src/RedisTestSolarwinds.py
+++ b/src/RedisTestSolarwinds.py
@@ -1,21 +1,26 @@
-import sys
+""" Implement the needed code to render Redismoke capable of interacting with Solarwinds """
+
 from RedisTest import RedisTestMsg
 
 class RedisTestMsgSolarwinds(RedisTestMsg):
+    """ Implement a RedisTestMsg interface that Solarwinds is capable of reading """
     def _failure(self):
         """ Print a standardized test failure message """
-        if self.reason is not None:
-            return "FAILURE[{}]: {}. Reason: {}.".format(self.testId, self._action(), self.reason)
+        if self.reason:
+            msg = ("Statistic.{}: {}\n"
+                   "Message.{}: {}").format(
+                       self.server.name,
+                       '0',
+                       self.server.name,
+                       self.reason
+                   )
         else:
-            return "FAILURE[{}]: {}. See stack trace.".format(self.testId, self._action())
-        sys.stdout.flush()
+            msg = "Statistic.{}: {}".format(self.server.name, '0')
+        return msg
 
     def _success(self):
         """ Print a standardized test success message """
-        return "SUCCESS[{}]: {}.".format(self.testId, self._action())
+        return "Statistic.{}: {}".format(self.server.name, '1')
 
     def __str__(self):
-        if self.success:
-            return self._success()
-        else:
-            return self._failure()
+        return self._success() if self.success else self._failure()

--- a/src/redismoke.py
+++ b/src/redismoke.py
@@ -14,7 +14,7 @@ with open(sys.argv[1], 'r') as stream:
 while True:
     try:
         test = RedisTest(config)
-        test.write()
+        test.setup()
         test.check()
         test = None
         sleep(config['pool'] if 'pool' in config and config['pool'] != "" else 60)

--- a/src/redismoke.py
+++ b/src/redismoke.py
@@ -3,7 +3,7 @@
 import sys
 from time import sleep
 import yaml
-from RedisTest import RedisTest
+from RedisTest import RedisGroupTest
 
 with open(sys.argv[1], 'r') as stream:
     try:
@@ -13,9 +13,8 @@ with open(sys.argv[1], 'r') as stream:
 
 while True:
     try:
-        test = RedisTest(config)
-        test.setup()
-        test.check()
+        test = RedisGroupTest(config)
+        test.run()
         test = None
         sleep(config['pool'] if 'pool' in config and config['pool'] != "" else 60)
     except (KeyboardInterrupt, SystemExit):

--- a/src/redismoke.py
+++ b/src/redismoke.py
@@ -1,21 +1,45 @@
 """ Redismoke CLI """
 
-import sys
 from time import sleep
+import argparse
 import yaml
+from RedisTestSolarwinds import RedisTestMsgSolarwinds
 from RedisTest import RedisGroupTest
 
-with open(sys.argv[1], 'r') as stream:
+parser = argparse.ArgumentParser(description="Test Redis replica sets")
+parser.add_argument(
+    '--solarwinds',
+    dest='solarwinds',
+    action='store_true',
+    help="Solarwinds-compatible output",
+    )
+parser.add_argument(
+    '--config',
+    dest='config',
+    nargs='?',
+    help="Config file",
+    default='redismoke.yml')
+args = parser.parse_args()
+
+with open(args.config, 'r') as stream:
     try:
         config = yaml.load(stream)
     except yaml.YAMLError as exc:
         print(exc)
 
-while True:
+if args.solarwinds is not None:
     try:
-        test = RedisGroupTest(config)
-        test.run()
-        test = None
-        sleep(config['pool'] if 'pool' in config and config['pool'] != "" else 60)
+        test = RedisGroupTest(config, msgClass=RedisTestMsgSolarwinds)
+        ok = test.run()
+        exit(0 if ok else 3)
     except (KeyboardInterrupt, SystemExit):
-        exit(0)
+        exit(2)
+else:
+    while True:
+        try:
+            test = RedisGroupTest(config)
+            test.run()
+            test = None
+            sleep(config['pool'] if 'pool' in config and config['pool'] != "" else 60)
+        except (KeyboardInterrupt, SystemExit):
+            exit(0)


### PR DESCRIPTION
This PR implements a plugin output system, rendering redismoke capable of outputting in a variety of formats as long as one implements the RedisTestMsg abstract class.

As an exercise, I already implemented the RedisTestMsgOneline with a oneline human readeable output, and a RedisTestMsgSolarwinds class that conforms with what Solarwinds expects from a script output.