### PR TITLE
Catch more server errors

### DIFF
--- a/confs/config.yml
+++ b/confs/config.yml
@@ -26,7 +26,20 @@ masters:
         address: "slave3"
         port: 6379
         pass: ""
+      - name: "slave99" #this should be a FAILURE to resolve
+        address: "slave99"
+        port: 6379
+        pass: ""
   - name: "master2b" #this should be a SUCCESS write with minimal config
     address: "master2"
     slaves:
       - address: "slave3" #this should be a SUCCESS read with minimal config, while being listed as Unnamed
+  - name: "slave3b"
+    address: "slave3" #this should be a FAILURE to write since it's a slave
+    slaves:
+      - address: "slave4" #this shouldn't even be tested
+  - name: "master2c" #this should be a FAILURE because of connection refused
+    address: "master2"
+    port: 6380
+    slaves:
+      - address: "slave4" #this shouldn't even be tested

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - master2
   redismoke:
     build: .
-    command: --config /confs/config.yml
+    command: "--wait 2 --config /confs/config.yml"
     volumes:
       - ./confs:/confs
     depends_on:

--- a/docker-compose_solarwinds.yml
+++ b/docker-compose_solarwinds.yml
@@ -48,7 +48,7 @@ services:
       - master2
   redismoke:
     build: .
-    command: "--config /confs/config.yml --solarwinds"
+    command: "--wait 2 --config /confs/config.yml --solarwinds"
     volumes:
       - ./confs:/confs
     depends_on:

--- a/src/RedisTest.py
+++ b/src/RedisTest.py
@@ -14,6 +14,7 @@ def _genRandomString(length):
     return ''.join(random.choice(string.ascii_lowercase) for i in range(length))
 
 class RedisGroupTest(object):
+    # pylint: disable=R0903
     """ A group of test instances, each with its own Redis master """
     def __init__(self, conf, msgClass=None):
         self.masters = [RedisMaster(master) for master in conf['masters']]
@@ -85,6 +86,7 @@ class RedisTest(object):
         return self._masterOk() and self._replicasOk()
 
 class RedisTestMsg(object):
+    # pylint: disable=R0903
     """ Abstract class of a Redis test result """
     def __init__(self, testId, action, server):
         self.testId = testId
@@ -113,6 +115,7 @@ class RedisTestMsg(object):
         raise NotImplementedError
 
 class RedisTestMsgOneline(RedisTestMsg):
+    # pylint: disable=R0903
     """ Informative message of the test result """
     def _failure(self):
         """ Print a standardized test failure message """

--- a/src/RedisTestSolarwinds.py
+++ b/src/RedisTestSolarwinds.py
@@ -3,6 +3,7 @@
 from RedisTest import RedisTestMsg
 
 class RedisTestMsgSolarwinds(RedisTestMsg):
+    # pylint: disable=R0903
     """ Implement a RedisTestMsg interface that Solarwinds is capable of reading """
     def _failure(self):
         """ Print a standardized test failure message """

--- a/src/redismoke.py
+++ b/src/redismoke.py
@@ -19,6 +19,12 @@ parser.add_argument(
     nargs='?',
     help="Config file",
     default='redismoke.yml')
+parser.add_argument(
+    '--wait',
+    dest='wait',
+    nargs='?',
+    help="Wait seconds before running",
+    default=0)
 args = parser.parse_args()
 
 with open(args.config, 'r') as stream:
@@ -26,6 +32,9 @@ with open(args.config, 'r') as stream:
         config = yaml.load(stream)
     except yaml.YAMLError as exc:
         print(exc)
+
+if args.wait is not None:
+    sleep(int(args.wait))
 
 if args.solarwinds is not None:
     try:


### PR DESCRIPTION
With this PR, we now catch all errors that the redis-py lib may throw in a nice way, still outputting in the required format.

Also, I've added a wait option to ensure that the redismoke script only starts after the redis containers are all up. May be used for similar reasons in conjunction with SolarWinds, also.